### PR TITLE
add default ignored repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,8 @@ venv*/
 .dmypy.json
 dmypy.json
 
+# Ruff
+.ruff_cache
+
 # Pyre type checker
 .pyre/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add default ignored_rep configuration. All those folders while not be visited by the linter.
+- Add default `ignored_rep` configuration. All those folders while not be visited by the
+  linter.
   - `node_modules`
   - `.vscode/`
   - `__pycache__/`
@@ -48,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `venv.bak/`
   - `.venv/`
   - `.env/`
-- Add progress bar to the cli
+- Add progress bar to the cli.
 
 ## [0.1.0] - 21-03-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add default ignored_rep configuration. All those folders while not be visited by the linter.
+  - `node_modules`
+  - `.vscode/`
+  - `__pycache__/`
+  - `build/`
+  - `develop-eggs/`
+  - `dist/`
+  - `downloads/`
+  - `eggs/`
+  - `.eggs/`
+  - `lib/`
+  - `lib64/`
+  - `parts/`
+  - `sdist/`
+  - `var/`
+  - `wheels/`
+  - `pip-wheel-metadata/`
+  - `share/python-wheels/`
+  - `htmlcov/`
+  - `.tox/`
+  - `.nox/`
+  - `.hypothesis/`
+  - `.pytest_cache/`
+  - `docs/_build/`
+  - `__pypackages__/`
+  - `.mypy_cache/`
+  - `.ruff_cache`
+  - `.pyre/`
+  - `env/`
+  - `venv/`
+  - `ENV/`
+  - `env.bak/`
+  - `venv.bak/`
+  - `.venv/`
+  - `.env/`
 - Add progress bar to the cli
 
 ## [0.1.0] - 21-03-2024

--- a/README.md
+++ b/README.md
@@ -71,6 +71,43 @@ The product output look like this.
 
 `file_path:line:column error_code display_function_detected error_name`
 
+By default we disable the linter in some folders.
+
+- `node_modules`
+- `.vscode/`
+- `__pycache__/`
+- `build/`
+- `develop-eggs/`
+- `dist/`
+- `downloads/`
+- `eggs/`
+- `.eggs/`
+- `lib/`
+- `lib64/`
+- `parts/`
+- `sdist/`
+- `var/`
+- `wheels/`
+- `pip-wheel-metadata/`
+- `share/python-wheels/`
+- `htmlcov/`
+- `.tox/`
+- `.nox/`
+- `.hypothesis/`
+- `.pytest_cache/`
+- `docs/_build/`
+- `__pypackages__/`
+- `.mypy_cache/`
+- `.ruff_cache`
+- `.pyre/`
+- `env/`
+- `venv/`
+- `ENV/`
+- `env.bak/`
+- `venv.bak/`
+- `.venv/`
+- `.env/`
+
 #### Example
 
 <!-- markdownlint-disable MD013 -->

--- a/cli_app/cli.py
+++ b/cli_app/cli.py
@@ -109,7 +109,7 @@ def _is_ignored_rep(ignored_rep: list[Path], path: Path) -> bool:
         True if path is in an ignored repository, False otherwise.
     """
     for rep in ignored_rep:
-        if all(i in path.parts for i in rep.parts):
+        if all(part in path.parts for part in rep.parts):
             return True
 
     return False

--- a/cli_app/cli.py
+++ b/cli_app/cli.py
@@ -97,6 +97,24 @@ def is_a_file(file_name: Path) -> Path | None:
     return file_name
 
 
+def _is_ignored_rep(ignored_rep: list[Path], path: Path) -> bool:
+    """
+    Check if given path is in an ignored repository.
+
+    Args:
+        ignored_rep: All ignored repositories
+        path: Path to check.
+
+    Returns:
+        True if path is in an ignored repository, False otherwise.
+    """
+    for rep in ignored_rep:
+        if all(i in path.parts for i in rep.parts):
+            return True
+
+    return False
+
+
 @APP.command(name="lint", help="lint the code to find print")
 def lint(
     path: Path = typer.Argument(
@@ -131,9 +149,10 @@ def lint(
     all_ignored_files = []
     issues = []
     for file_path in track(files_path, description="Processing..."):
-        if file_path.absolute() in [
-            Path(path).absolute() for path in config.ignored_files
-        ]:
+        if (
+            file_path.absolute()
+            in [Path(path).absolute() for path in config.ignored_files]
+        ) or _is_ignored_rep(config.ignored_rep, file_path):
             continue
 
         tree, ignored_lines, ignored_files = parse_file(

--- a/create_ignored_rep_for_test.sh
+++ b/create_ignored_rep_for_test.sh
@@ -1,0 +1,105 @@
+mkdir tests/testing_files/config/ignored_rep/
+mkdir tests/testing_files/config/ignored_rep/node_modules/
+touch tests/testing_files/config/ignored_rep/node_modules/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/node_modules/toto.py
+mkdir tests/testing_files/config/ignored_rep/.vscode/
+touch tests/testing_files/config/ignored_rep/.vscode/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.vscode/toto.py
+mkdir tests/testing_files/config/ignored_rep/__pycache__/
+touch tests/testing_files/config/ignored_rep/__pycache__/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/__pycache__/toto.py
+mkdir tests/testing_files/config/ignored_rep/build/
+touch tests/testing_files/config/ignored_rep/build/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/build/toto.py
+mkdir tests/testing_files/config/ignored_rep/develop-eggs/
+touch tests/testing_files/config/ignored_rep/develop-eggs/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/develop-eggs/toto.py
+mkdir tests/testing_files/config/ignored_rep/dist/
+touch tests/testing_files/config/ignored_rep/dist/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/dist/toto.py
+mkdir tests/testing_files/config/ignored_rep/downloads/
+touch tests/testing_files/config/ignored_rep/downloads/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/downloads/toto.py
+mkdir tests/testing_files/config/ignored_rep/eggs/
+touch tests/testing_files/config/ignored_rep/eggs/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/eggs/toto.py
+mkdir tests/testing_files/config/ignored_rep/.eggs/
+touch tests/testing_files/config/ignored_rep/.eggs/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.eggs/toto.py
+mkdir tests/testing_files/config/ignored_rep/lib/
+touch tests/testing_files/config/ignored_rep/lib/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/lib/toto.py
+mkdir tests/testing_files/config/ignored_rep/lib64/
+touch tests/testing_files/config/ignored_rep/lib64/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/lib64/toto.py
+mkdir tests/testing_files/config/ignored_rep/parts/
+touch tests/testing_files/config/ignored_rep/parts/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/parts/toto.py
+mkdir tests/testing_files/config/ignored_rep/sdist/
+touch tests/testing_files/config/ignored_rep/sdist/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/sdist/toto.py
+mkdir tests/testing_files/config/ignored_rep/var/
+touch tests/testing_files/config/ignored_rep/var/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/var/toto.py
+mkdir tests/testing_files/config/ignored_rep/wheels/
+touch tests/testing_files/config/ignored_rep/wheels/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/wheels/toto.py
+mkdir tests/testing_files/config/ignored_rep/pip-wheel-metadata/
+touch tests/testing_files/config/ignored_rep/pip-wheel-metadata/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/pip-wheel-metadata/toto.py
+mkdir tests/testing_files/config/ignored_rep/share/
+mkdir tests/testing_files/config/ignored_rep/share/python-wheels/
+touch tests/testing_files/config/ignored_rep/share/python-wheels/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/share/python-wheels/toto.py
+mkdir tests/testing_files/config/ignored_rep/htmlcov/
+touch tests/testing_files/config/ignored_rep/htmlcov/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/htmlcov/toto.py
+mkdir tests/testing_files/config/ignored_rep/.tox/
+touch tests/testing_files/config/ignored_rep/.tox/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.tox/toto.py
+mkdir tests/testing_files/config/ignored_rep/.nox/
+touch tests/testing_files/config/ignored_rep/.nox/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.nox/toto.py
+mkdir tests/testing_files/config/ignored_rep/.hypothesis/
+touch tests/testing_files/config/ignored_rep/.hypothesis/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.hypothesis/toto.py
+mkdir tests/testing_files/config/ignored_rep/.pytest_cache/
+touch tests/testing_files/config/ignored_rep/.pytest_cache/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.pytest_cache/toto.py
+mkdir tests/testing_files/config/ignored_rep/docs/
+mkdir tests/testing_files/config/ignored_rep/docs/_build/
+touch tests/testing_files/config/ignored_rep/docs/_build/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/docs/_build/toto.py
+mkdir tests/testing_files/config/ignored_rep/__pypackages__/
+touch tests/testing_files/config/ignored_rep/__pypackages__/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/__pypackages__/toto.py
+mkdir tests/testing_files/config/ignored_rep/.mypy_cache/
+touch tests/testing_files/config/ignored_rep/.mypy_cache/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.mypy_cache/toto.py
+mkdir tests/testing_files/config/ignored_rep/.pyre/
+touch tests/testing_files/config/ignored_rep/.pyre/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.pyre/toto.py
+mkdir tests/testing_files/config/ignored_rep/env/
+touch tests/testing_files/config/ignored_rep/env/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/env/toto.py
+mkdir tests/testing_files/config/ignored_rep/venv/
+touch tests/testing_files/config/ignored_rep/venv/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/venv/toto.py
+mkdir tests/testing_files/config/ignored_rep/ENV/
+touch tests/testing_files/config/ignored_rep/ENV/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/ENV/toto.py
+mkdir tests/testing_files/config/ignored_rep/env.bak/
+touch tests/testing_files/config/ignored_rep/env.bak/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/env.bak/toto.py
+mkdir tests/testing_files/config/ignored_rep/venv.bak/
+touch tests/testing_files/config/ignored_rep/venv.bak/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/venv.bak/toto.py
+mkdir tests/testing_files/config/ignored_rep/.venv/
+touch tests/testing_files/config/ignored_rep/.venv/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.venv/toto.py
+mkdir tests/testing_files/config/ignored_rep/.env/
+touch tests/testing_files/config/ignored_rep/.env/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.env/toto.py
+mkdir tests/testing_files/config/ignored_rep/.ruff_cache/
+touch tests/testing_files/config/ignored_rep/.ruff_cache/toto.py
+echo "print('Hello world')" > tests/testing_files/config/ignored_rep/.ruff_cache/toto.py

--- a/doc/changelog/CHANGELOG.fr.md
+++ b/doc/changelog/CHANGELOG.fr.md
@@ -11,6 +11,46 @@ et ce projet adhère au principe de la [Semantic Versioning](https://semver.org/
 
 ## [Non publié]
 
+### Ajouté
+
+- Ajout d'une valeur par défaut pour la configuration `ignored_rep`. Tout ces dossier ne
+  seront pas visités par le linter
+  - `node_modules`
+  - `.vscode/`
+  - `__pycache__/`
+  - `build/`
+  - `develop-eggs/`
+  - `dist/`
+  - `downloads/`
+  - `eggs/`
+  - `.eggs/`
+  - `lib/`
+  - `lib64/`
+  - `parts/`
+  - `sdist/`
+  - `var/`
+  - `wheels/`
+  - `pip-wheel-metadata/`
+  - `share/python-wheels/`
+  - `htmlcov/`
+  - `.tox/`
+  - `.nox/`
+  - `.hypothesis/`
+  - `.pytest_cache/`
+  - `docs/_build/`
+  - `__pypackages__/`
+  - `.mypy_cache/`
+  - `.ruff_cache`
+  - `.pyre/`
+  - `env/`
+  - `venv/`
+  - `ENV/`
+  - `env.bak/`
+  - `venv.bak/`
+  - `.venv/`
+  - `.env/`
+- Ajout d'une barre de progression au cli.
+
 ## [0.1.0] - 21-03-2024
 
 ### Ajouté

--- a/doc/readme/README.fr.md
+++ b/doc/readme/README.fr.md
@@ -72,6 +72,43 @@ Le résultat produit resemble à ça.
 
 `file_path:line:column error_code display_function_detected error_name`
 
+Par défaut nous avons désactiver le linter sur certains dossiers.
+
+- `node_modules`
+- `.vscode/`
+- `__pycache__/`
+- `build/`
+- `develop-eggs/`
+- `dist/`
+- `downloads/`
+- `eggs/`
+- `.eggs/`
+- `lib/`
+- `lib64/`
+- `parts/`
+- `sdist/`
+- `var/`
+- `wheels/`
+- `pip-wheel-metadata/`
+- `share/python-wheels/`
+- `htmlcov/`
+- `.tox/`
+- `.nox/`
+- `.hypothesis/`
+- `.pytest_cache/`
+- `docs/_build/`
+- `__pypackages__/`
+- `.mypy_cache/`
+- `.ruff_cache`
+- `.pyre/`
+- `env/`
+- `venv/`
+- `ENV/`
+- `env.bak/`
+- `venv.bak/`
+- `.venv/`
+- `.env/`
+
 #### Exemple
 
 <!-- markdownlint-disable MD013 -->
@@ -297,7 +334,6 @@ disabled_rules = ["PPL001"]
 Pour voir les prochaines fonctionnalités qui seront développées regarder [TODO](TOTO.md).
 Voici une petite, liste non exhaustive de ce qui est prévu dans les versions futures.
 
-- Utiliser le linter sur un fichier, plus seulement sur des dossiers.
 - Ignorer un bloque de code.
 - Ignorer la ligne suivante
 - Linter les fonctions d'affichage de d'autres librairies

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # Remove python cache files
 clean:
-    find . \( -name __pycache__ -o -name "*.pyc" \) -delete
+    -find . \( -name __pycache__ -o -name "*.pyc" \) -delete
 
 # Clear and display pwd
 clear:
@@ -12,10 +12,13 @@ install: clean clear
     poetry install --no-dev --remove-untracked
 
 # install all dependencies with poetry and npm
-install-all: clean clear
+install-dev: clean clear
     poetry install --remove-untracked
     npm install
-    sudo npm install markdownlint-cli2 --global
+    npm install markdownlint-cli2
+
+create_rep_for_test:
+    ./create_ignored_rep_for_test.sh
 
 # Do a clean install of pre-commit dependencies
 preinstall: clean clear

--- a/printlinter/__init__.py
+++ b/printlinter/__init__.py
@@ -3,7 +3,7 @@
 
 # Local imports
 from .classes import IgnoreFile, IgnoreLine, IssueEnum, IssueInfo  # noqa: F401
-from .config import Config  # noqa: F401
+from .config import DEFAULT_IGNORED_REP, Config  # noqa: F401
 from .ignored_processing import get_not_ignore_issue  # noqa: F401
 from .parser import (  # noqa: F401
     enumerate_file,

--- a/printlinter/config.py
+++ b/printlinter/config.py
@@ -34,6 +34,53 @@ CONFIG_DEFAULT_FILES = [
 
 MAX_MAJOR = 3
 MAX_MINOR = 11
+DEFAULT_IGNORED_REP = [
+    # npm
+    Path("node_modules/"),
+    # VSCode
+    Path(".vscode/"),
+    # Byte-compiled
+    Path("__pycache__/"),
+    # Distribution / packaging
+    Path("build/"),
+    Path("develop-eggs/"),
+    Path("dist/"),
+    Path("downloads/"),
+    Path("eggs/"),
+    Path(".eggs/"),
+    Path("lib/"),
+    Path("lib64/"),
+    Path("parts/"),
+    Path("sdist/"),
+    Path("var/"),
+    Path("wheels/"),
+    Path("pip-wheel-metadata/"),
+    Path("share/python-wheels/"),
+    # Unit test / coverage reports
+    Path("htmlcov/"),
+    Path(".tox/"),
+    Path(".nox/"),
+    Path(".hypothesis/"),
+    Path(".pytest_cache/"),
+    # Sphinx documentation
+    Path("docs/_build/"),
+    # PEP 582
+    Path("__pypackages__/"),
+    # mypy
+    Path(".mypy_cache/"),
+    # ruff
+    Path(".ruff_cache"),
+    # Pyre type checker
+    Path(".pyre/"),
+    # Environments
+    Path("env/"),
+    Path("venv/"),
+    Path("ENV/"),
+    Path("env.bak/"),
+    Path("venv.bak/"),
+    Path(".venv/"),
+    Path(".env/"),
+]
 
 
 @dataclass
@@ -45,6 +92,9 @@ class Config:
 
     ignored_files: list[str]
     "Ignored files."
+
+    ignored_rep: list[Path]
+    "Ignored repositories."
 
     disabled_rules: list[str]
     "Disabled rules."
@@ -69,6 +119,9 @@ class Config:
         self.target_version = self._fix_target_version(config)
         self.ignored_files = cast(list[str], config.get("ignored_files", []))
         self.disabled_rules = cast(list[str], config.get("disabled_rules", []))
+
+        # TODO: Add this in user config and merge list give by user and default list
+        self.ignored_rep = DEFAULT_IGNORED_REP
 
     def _read_config(
         self,

--- a/tests/cli/test_command.py
+++ b/tests/cli/test_command.py
@@ -57,5 +57,12 @@ def test_cli_command_lint_w_path(
         ],
     )
 
+    assert_that(result.exit_code).is_equal_to(expected_exit_code)
+
+
+def test_cli_on_default_ignored_rep(pnv_soft_reset, testing_files):
+    result = runner.invoke(APP, ["lint", f"{testing_files}/config/ignored_rep"])
+
     with soft_assertions():
-        assert_that(result.exit_code).is_equal_to(expected_exit_code)
+        assert_that(result.exit_code).is_equal_to(0)
+        assert_that(result.stdout).contains("Found 1 errors")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from assertpy import assert_that, soft_assertions
 
 # First party imports
-from printlinter import Config
+from printlinter import DEFAULT_IGNORED_REP, Config
 
 # Local imports
 from ..conftest import INPUT_FILE_PATH
@@ -233,6 +233,7 @@ def test_config_from_given_file(
         assert_that(conf.target_version).is_equal_to(expect_target_version)
         assert_that(conf.ignored_files).is_equal_to(expect_ignored_files)
         assert_that(conf.disabled_rules).is_equal_to(expect_disabled_rules)
+        assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
 @pytest.mark.parametrize(
@@ -289,6 +290,7 @@ def test_config_from_auto_file(
         assert_that(conf.target_version).is_equal_to(expect_target_version)
         assert_that(conf.ignored_files).contains_only(*expect_ignored_files)
         assert_that(conf.disabled_rules).contains_only(*expect_disabled_rules)
+        assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
 def test_config_from_auto_no_config_file():
@@ -300,6 +302,7 @@ def test_config_from_auto_no_config_file():
         assert_that(conf.target_version).is_equal_to((3, 10))
         assert_that(conf.ignored_files).is_empty()
         assert_that(conf.disabled_rules).is_empty()
+        assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
 @pytest.mark.parametrize(
@@ -317,6 +320,7 @@ def test_config_default_config_because_empty_config_file(given_file):
         assert_that(conf.target_version).is_equal_to((3, 10))
         assert_that(conf.ignored_files).is_empty()
         assert_that(conf.disabled_rules).is_empty()
+        assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
 def test_config_default_because_no_config_file():
@@ -328,6 +332,7 @@ def test_config_default_because_no_config_file():
         assert_that(conf.target_version).is_equal_to((3, 10))
         assert_that(conf.ignored_files).is_empty()
         assert_that(conf.disabled_rules).is_empty()
+        assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
 @pytest.mark.parametrize(

--- a/tests/testing_files/config/ignored_rep/docs/_build/toto.py
+++ b/tests/testing_files/config/ignored_rep/docs/_build/toto.py
@@ -1,0 +1,1 @@
+print("Hello world")

--- a/tests/testing_files/config/ignored_rep/share/python-wheels/toto.py
+++ b/tests/testing_files/config/ignored_rep/share/python-wheels/toto.py
@@ -1,0 +1,1 @@
+print("Hello world")

--- a/tests/testing_files/config/ignored_rep/toto/toto.py
+++ b/tests/testing_files/config/ignored_rep/toto/toto.py
@@ -1,0 +1,1 @@
+print("Hello world")


### PR DESCRIPTION
### Added

- Add default ignored_rep configuration. All those folders while not be visited by the linter.
  - `node_modules`
  - `.vscode/`
  - `__pycache__/`
  - `build/`
  - `develop-eggs/`
  - `dist/`
  - `downloads/`
  - `eggs/`
  - `.eggs/`
  - `lib/`
  - `lib64/`
  - `parts/`
  - `sdist/`
  - `var/`
  - `wheels/`
  - `pip-wheel-metadata/`
  - `share/python-wheels/`
  - `htmlcov/`
  - `.tox/`
  - `.nox/`
  - `.hypothesis/`
  - `.pytest_cache/`
  - `docs/_build/`
  - `__pypackages__/`
  - `.mypy_cache/`
  - `.ruff_cache`
  - `.pyre/`
  - `env/`
  - `venv/`
  - `ENV/`
  - `env.bak/`
  - `venv.bak/`
  - `.venv/`
  - `.env/`