### PR TITLE
Feature/minimized output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: isort
         name: isort (python)
   - repo: https://github.com/ambv/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         language_version: python3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a configuration option for a minimize output: `output_level`.
+  Possible values:
+
+  - 1 for a really short output with just the number of errors
+  - 2 for a short output with number of errors by files
+  - 3 for a medium output with number of errors by files and which error and at which lines
+
 ## [0.3.0] - 09-08-2024
 
 ### Added

--- a/justfile
+++ b/justfile
@@ -64,7 +64,6 @@ autorebase: clean clear
 coverage: clean clear
     pytest --cov-report term-missing:skip-covered --cov
 
-
 # rebase on main
 rebaseM: clean clear
     git checkout main

--- a/printlinter/__init__.py
+++ b/printlinter/__init__.py
@@ -1,4 +1,3 @@
-# Local imports
 """Print-Linter project's code."""
 
 # Local imports
@@ -8,6 +7,7 @@ from .classes import (  # noqa: F401
     IgnoredLine,
     IssueEnum,
     IssueInfo,
+    OutputLevel,
 )
 from .config import DEFAULT_IGNORED_REP, Config  # noqa: F401
 from .ignored_processing import get_not_ignored_issue  # noqa: F401

--- a/printlinter/classes.py
+++ b/printlinter/classes.py
@@ -3,7 +3,7 @@
 # Standard imports
 from collections import namedtuple
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, auto
 from pathlib import Path
 
 Issue = namedtuple("Issue", ["err_code", "name"])
@@ -22,6 +22,15 @@ class IssueEnum(Issue, Enum):
     SYSSTDERRWRITELINESDETECT = Issue(
         err_code="PPL006", name="sys.stderr.writelines-detected"
     )
+
+
+class OutputLevel(Enum):
+    """Minimize level enum."""
+
+    DEFAULT = auto()
+    L1 = auto()
+    L2 = auto()
+    L3 = auto()
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "printlinter"
 version = "0.3.0"
 description = "print linter to know where is the test print"
-authors = ["ulysse <ulysse.chosson@obspm.fr>"]
+authors = ["ulysse <u.chosson@proton.me>"]
 license = "EUPL v1.2"
 readme = "README.md"
 packages = [{ include = "cli_app" }, { include = "printlinter" }]
@@ -41,9 +41,10 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "--xdoctest -n auto"
+addopts = "--xdoctest -n auto -m 'not very_slow'"
 markers = [
-    "slow", # A particulary slow test
+    "slow",      # A particulary slow test
+    "very_slow", # Realy REALY slow tests
 ]
 
 [tool.coverage.run]
@@ -168,3 +169,6 @@ max-complexity = 10
 
 [tool.ruff.flake8-annotations]
 suppress-none-returning = true
+
+[tool.printlinter]
+output_level = 3

--- a/tests/cli/test_on_real_project.py
+++ b/tests/cli/test_on_real_project.py
@@ -35,7 +35,9 @@ def _get_project(url: str, dest_folder: Path) -> None:
             "mypy-1.10.0",
             "https://github.com/python/mypy/archive/refs/tags/v1.10.0.tar.gz",
             297,
-            """/TEST_REAL_PROJECTS/mypy-1.10.0/misc/cherry-pick-typeshed.py:66:4: PPL001 `print(f"Cherry-picked commit {commit} from {typeshed_dir}")` print-detected""",
+            """/TEST_REAL_PROJECTS/mypy-1.10.0/misc/cherry-pick-typeshed.py:66:4: """
+            """PPL001 `print(f"Cherry-picked commit {commit} from {typeshed_dir}")` """
+            """print-detected""",
             id="mypy",
         ),
         # TODO: Reactivate this test when we can put filename with regex in ignored file
@@ -43,30 +45,38 @@ def _get_project(url: str, dest_folder: Path) -> None:
         #     "django-5.0.6",
         #     "https://github.com/django/django/archive/refs/tags/5.0.6.tar.gz",
         #     82,
-        #     """`print("\tResource %s for language %s" % (resource, lang))` print-detected""",
+        #     """`print("\tResource %s for language %s" % (resource, lang))` """
+        #     """print-detected""",
         #     "manage_translations.py",
         #     "196:12",
         #     id="django",
         # ),
         param(
             "exoplanet.eu-v2.15.1",
-            "https://gitlab.obspm.fr/exoplanet/exoplanet.eu/-/archive/v2.15.1/exoplanet.eu-v2.15.1.tar.gz",
+            "https://gitlab.obspm.fr/exoplanet/exoplanet.eu/-/archive/v2.15.1/"
+            "exoplanet.eu-v2.15.1.tar.gz",
             52,
-            """/TEST_REAL_PROJECTS/exoplanet.eu-v2.15.1/doc/disks/py-scripts/link_rel_star_and_json_star.py:59:0: PPL001 `print("OK 👍")` print-detected""",
+            """/TEST_REAL_PROJECTS/exoplanet.eu-v2.15.1/doc/disks/py-scripts/"""
+            """link_rel_star_and_json_star.py:59:0: PPL001 `print("OK 👍")` """
+            """print-detected""",
             id="exoplanet.eu",
         ),
         param(
             "exoimport-v1.4.1",
-            "https://gitlab.obspm.fr/exoplanet/exoimport/-/archive/v1.4.1/exoimport-v1.4.1.tar.gz",
+            "https://gitlab.obspm.fr/exoplanet/exoimport/-/archive/v1.4.1/"
+            "exoimport-v1.4.1.tar.gz",
             8,
-            """/TEST_REAL_PROJECTS/exoimport-v1.4.1/cli_app/translate.py:93:4: PPL001 `print(text2art("Filtration"))` print-detected""",
+            """/TEST_REAL_PROJECTS/exoimport-v1.4.1/cli_app/translate.py:93:4: """
+            """PPL001 `print(text2art("Filtration"))` print-detected""",
             id="exoimport",
         ),
         param(
             "py-linq-sql-v1.11.0-pre-release",
-            "https://gitlab.obspm.fr/exoplanet/py-linq-sql/-/archive/v1.11.0-pre-release/py-linq-sql-v1.11.0-pre-release.tar.gz",
+            "https://gitlab.obspm.fr/exoplanet/py-linq-sql/-/archive/"
+            "v1.11.0-pre-release/py-linq-sql-v1.11.0-pre-release.tar.gz",
             2,
-            """/TEST_REAL_PROJECTS/py-linq-sql-v1.11.0-pre-release/tests/operators/test_logical_op.py:163:4: PPL001 `print(record)` print-detected""",
+            """/TEST_REAL_PROJECTS/py-linq-sql-v1.11.0-pre-release/tests/operators/"""
+            """test_logical_op.py:163:4: PPL001 `print(record)` print-detected""",
             id="py-linq-sql",
         ),
         param(
@@ -80,26 +90,33 @@ def _get_project(url: str, dest_folder: Path) -> None:
             "botocore-1.34.114",
             "https://github.com/boto/botocore/archive/refs/tags/1.34.114.tar.gz",
             6,
-            """/TEST_REAL_PROJECTS/botocore-1.34.114/tests/unit/response_parsing/test_response_parsing.py:108:8: PPL001 `print(d2)` print-detected""",
+            """/TEST_REAL_PROJECTS/botocore-1.34.114/tests/unit/response_parsing/"""
+            """test_response_parsing.py:108:8: PPL001 `print(d2)` print-detected""",
             id="boto core",
         ),
         param(
             "urllib3-2.2.1",
-            "https://github.com/urllib3/urllib3/releases/download/2.2.1/urllib3-2.2.1.tar.gz",
+            "https://github.com/urllib3/urllib3/releases/download/2.2.1/"
+            "urllib3-2.2.1.tar.gz",
             3,
-            """/TEST_REAL_PROJECTS/urllib3-2.2.1/dummyserver/app.py:56:4: PPL001 `print("scope", request.scope)` print-detected""",
+            """/TEST_REAL_PROJECTS/urllib3-2.2.1/dummyserver/app.py:56:4: """
+            """PPL001 `print("scope", request.scope)` print-detected""",
             id="urllib 3",
         ),
         param(
             "requests-2.32.2",
-            "https://github.com/psf/requests/releases/download/v2.32.2/requests-2.32.2.tar.gz",
+            "https://github.com/psf/requests/releases/download/v2.32.2/"
+            "requests-2.32.2.tar.gz",
             6,
-            """/TEST_REAL_PROJECTS/requests-2.32.2/src/requests/help.py:130:4: PPL001 `print(json.dumps(info(), sort_keys=True, indent=2))` print-detected""",
+            """/TEST_REAL_PROJECTS/requests-2.32.2/src/requests/help.py:130:4: """
+            """PPL001 `print(json.dumps(info(), sort_keys=True, indent=2))` """
+            """print-detected""",
             id="request",
         ),
     ],
 )
 @pytest.mark.slow()
+@pytest.mark.very_slow()
 def test_on_real_projects(
     tmp_path,
     pnv_soft_reset,

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,162 @@
+# Pytest imports
+import pytest
+from pytest import param
+
+# Standard imports
+from pathlib import Path
+
+# Third party imports
+from assertpy import assert_that, soft_assertions
+
+# First party imports
+from cli_app.cli import _get_errors_msg_by_file, _is_a_file, _is_ignored_rep
+from printlinter import IssueEnum, IssueInfo
+
+# Local imports
+from ..conftest import INPUT_FILE_PATH
+
+TESTING_FILES_PATH = INPUT_FILE_PATH / "print"
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        param(
+            TESTING_FILES_PATH / "toto_0.py",
+            TESTING_FILES_PATH / "toto_0.py",
+            id="simple file",
+        ),
+        param(
+            Path("."),
+            None,
+            id='default, "."',
+        ),
+    ],
+)
+def test_is_a_file_success(path, expected):
+    assert _is_a_file(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        param(TESTING_FILES_PATH / "toto", id="Given path not exist"),
+        param(TESTING_FILES_PATH, id="Given path is a directory"),
+    ],
+)
+def test_is_a_file_fail(path):
+    with pytest.raises(FileNotFoundError):
+        _is_a_file(path)
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        param(
+            Path("a/d.py"),
+            True,
+            id="ignored in first folder",
+        ),
+        param(
+            Path("a/b/d.py"),
+            True,
+            id="ignored in second folder",
+        ),
+        param(
+            Path("a/b/c/d.py"),
+            True,
+            id="ignored in third folder",
+        ),
+        param(
+            Path("toto.py"),
+            False,
+            id="Not ignored file in cwd",
+        ),
+        param(
+            Path("z/toto.py"),
+            False,
+            id="Not ignored file in a fodler",
+        ),
+    ],
+)
+def test_is_ignored_rep(path, expected):
+    assert (
+        _is_ignored_rep(
+            [
+                Path("a"),
+                Path("a/b"),
+                Path("a/b/c/"),
+            ],
+            path,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "with_number_and_lines, expected",
+    [
+        param(
+            True,
+            [
+                "[bold]toto.py[/bold]",
+                "3 errors detected",
+                "[bold red]PPL002[/bold red]",
+                "[bold red]PPL001[/bold red]",
+                "at lines",
+                "[bold]titi.py[/bold] - 1 errors detected ([bold red]PPL001[/bold red]"
+                ") at lines 5",
+            ],
+            id="With number and lines",
+        ),
+        param(
+            False,
+            [
+                "[bold]toto.py[/bold] - 3 errors detected",
+                "[bold]titi.py[/bold] - 1 errors detected",
+            ],
+            id="Without number and lines",
+        ),
+    ],
+)
+def test_get_errors_msg_by_file(with_number_and_lines, expected):
+    issues = [
+        IssueInfo(
+            IssueEnum.PRINTDETECT,
+            num_line=5,
+            num_col=0,
+            line_as_str="print('toto')",
+            from_file=Path("toto.py"),
+            ignored=False,
+        ),
+        IssueInfo(
+            IssueEnum.PRINTDETECT,
+            num_line=7,
+            num_col=0,
+            line_as_str="print('toto2')",
+            from_file=Path("toto.py"),
+            ignored=False,
+        ),
+        IssueInfo(
+            IssueEnum.PRETTYPRINTDETECT,
+            num_line=9,
+            num_col=0,
+            line_as_str="pprint('toto3')",
+            from_file=Path("toto.py"),
+            ignored=False,
+        ),
+        IssueInfo(
+            IssueEnum.PRINTDETECT,
+            num_line=5,
+            num_col=0,
+            line_as_str="print('titi')",
+            from_file=Path("titi.py"),
+            ignored=False,
+        ),
+    ]
+
+    with soft_assertions():
+        for exp in expected:
+            assert_that(
+                _get_errors_msg_by_file(issues, with_number_and_lines)
+            ).contains(exp)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from assertpy import assert_that, soft_assertions
 
 # First party imports
-from printlinter import DEFAULT_IGNORED_REP, Config
+from printlinter import DEFAULT_IGNORED_REP, Config, OutputLevel
 
 # Local imports
 from ..conftest import INPUT_FILE_PATH
@@ -19,8 +19,10 @@ from .conftest import change_cwd
 TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
 
 
+# TODO: Create a config generator and generate X (100?) tests with it.
 @pytest.mark.parametrize(
-    "given_file, expect_target_version, expect_ignored_files, expect_disabled_rules, expect_color",
+    "given_file, expect_target_version, expect_ignored_files, expect_disabled_rules, "
+    "expect_color, expect_output_level",
     [
         # full config
         param(
@@ -29,6 +31,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["toto.py"],
             ["PPL001"],
             True,
+            OutputLevel.L1,
             id="yml file",
         ),
         param(
@@ -37,6 +40,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["titi.py"],
             ["PPL002"],
             False,
+            OutputLevel.L2,
             id="yaml file",
         ),
         param(
@@ -45,6 +49,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tutu.py"],
             ["PPL003"],
             True,
+            OutputLevel.L1,
             id="json file",
         ),
         param(
@@ -53,6 +58,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tata.py"],
             ["PPL004"],
             False,
+            OutputLevel.L3,
             id="toml file",
         ),
         # partial config
@@ -62,6 +68,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial yml file, only target_version",
         ),
         param(
@@ -70,6 +77,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["toto.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial yml file, only ignored_files",
         ),
         param(
@@ -78,6 +86,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL001"],
             True,
+            OutputLevel.DEFAULT,
             id="partial yml file, only disabled_rules",
         ),
         param(
@@ -86,6 +95,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial yml file, only color",
         ),
         param(
@@ -94,6 +104,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["toto.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial yml file, target_version and ignored_files",
         ),
         param(
@@ -102,6 +113,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL001"],
             True,
+            OutputLevel.DEFAULT,
             id="partial yml file, target_version and disabled rules",
         ),
         param(
@@ -110,6 +122,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["toto.py"],
             ["PPL001"],
             True,
+            OutputLevel.DEFAULT,
             id="partial yml file, ignored_files and disabled_rules",
         ),
         param(
@@ -118,6 +131,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial yml file, target_version and color",
         ),
         param(
@@ -126,6 +140,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["toto.py"],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial yml file, target_version, ignored_files and color",
         ),
         param(
@@ -134,6 +149,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial yaml file, only target_version",
         ),
         param(
@@ -142,6 +158,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["titi.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial yaml file, only ignored_files",
         ),
         param(
@@ -150,6 +167,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL002"],
             True,
+            OutputLevel.DEFAULT,
             id="partial yaml file, only disabled_rules",
         ),
         param(
@@ -158,6 +176,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial yaml file, only color",
         ),
         param(
@@ -166,6 +185,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["titi.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial yaml file, target_version and ignored_files",
         ),
         param(
@@ -174,6 +194,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL002"],
             True,
+            OutputLevel.DEFAULT,
             id="partial yaml file, target_version and disabled rules",
         ),
         param(
@@ -182,6 +203,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["titi.py"],
             ["PPL002"],
             True,
+            OutputLevel.DEFAULT,
             id="partial yaml file, ignored_files and disabled_rules",
         ),
         param(
@@ -190,6 +212,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial yaml file, target_version and color",
         ),
         param(
@@ -198,6 +221,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["titi.py"],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial yaml file, target_version, ignored_files and color",
         ),
         param(
@@ -206,6 +230,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial json file, only target_version",
         ),
         param(
@@ -214,6 +239,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tutu.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial json file, only ignored_files",
         ),
         param(
@@ -222,6 +248,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL003"],
             True,
+            OutputLevel.DEFAULT,
             id="partial json file, only disabled_rules",
         ),
         param(
@@ -230,6 +257,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial json file, only color",
         ),
         param(
@@ -238,6 +266,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tutu.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial json file, target_version and ignored_files",
         ),
         param(
@@ -246,6 +275,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL003"],
             True,
+            OutputLevel.DEFAULT,
             id="partial json file, target_version and disabled rules",
         ),
         param(
@@ -254,6 +284,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tutu.py"],
             ["PPL003"],
             True,
+            OutputLevel.DEFAULT,
             id="partial json file, ignored_files and disabled_rules",
         ),
         param(
@@ -262,6 +293,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial json file, target_version and color",
         ),
         param(
@@ -270,6 +302,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tutu.py"],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial json file, target_version, ignored_files and color",
         ),
         param(
@@ -278,6 +311,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial toml file, only target_version",
         ),
         param(
@@ -286,6 +320,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tata.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial toml file, only ignored_files",
         ),
         param(
@@ -294,6 +329,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL004"],
             True,
+            OutputLevel.DEFAULT,
             id="partial toml file, only disabled_rules",
         ),
         param(
@@ -302,6 +338,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial toml file, only color",
         ),
         param(
@@ -310,6 +347,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tata.py"],
             [],
             True,
+            OutputLevel.DEFAULT,
             id="partial toml file, only target_version and ignored_files",
         ),
         param(
@@ -318,6 +356,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             ["PPL004"],
             True,
+            OutputLevel.DEFAULT,
             id="partial toml file, only target_version and disabled rules",
         ),
         param(
@@ -326,6 +365,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tata.py"],
             ["PPL004"],
             True,
+            OutputLevel.DEFAULT,
             id="partial toml file, only ignored_files and disabled_rules",
         ),
         param(
@@ -334,6 +374,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial toml file, target_version and color",
         ),
         param(
@@ -342,6 +383,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["tata.py"],
             [],
             False,
+            OutputLevel.DEFAULT,
             id="partial toml file, target_version, ignored_files and color",
         ),
     ],
@@ -352,6 +394,7 @@ def test_config_from_given_file(
     expect_ignored_files,
     expect_disabled_rules,
     expect_color,
+    expect_output_level,
 ):
     conf = Config(TESTING_FILES_PATH / given_file)
     with soft_assertions():
@@ -359,6 +402,7 @@ def test_config_from_given_file(
         assert_that(conf.ignored_files).is_equal_to(expect_ignored_files)
         assert_that(conf.disabled_rules).is_equal_to(expect_disabled_rules)
         assert_that(conf.color).is_equal_to(expect_color)
+        assert_that(conf.output_level).is_equal_to(expect_output_level)
         assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
@@ -516,3 +560,8 @@ def test_config_from_file_error_on_given_file(given_file, error):
 def test_config_from_file_error_on_target_version(given_file, error):
     with pytest.raises(error):
         Config(TESTING_FILES_PATH / given_file)
+
+
+def test_config_from_file_error_on_output_level():
+    with pytest.raises(ValueError):
+        Config(TESTING_FILES_PATH / "errors/output_level_4.yml")

--- a/tests/testing_files/config/cli/output_level_1.yml
+++ b/tests/testing_files/config/cli/output_level_1.yml
@@ -1,0 +1,2 @@
+printlinter:
+  output_level: 1

--- a/tests/testing_files/config/cli/output_level_2.yml
+++ b/tests/testing_files/config/cli/output_level_2.yml
@@ -1,0 +1,2 @@
+printlinter:
+  output_level: 2

--- a/tests/testing_files/config/cli/output_level_3.yml
+++ b/tests/testing_files/config/cli/output_level_3.yml
@@ -1,0 +1,2 @@
+printlinter:
+  output_level: 3

--- a/tests/testing_files/config/errors/output_level_4.yml
+++ b/tests/testing_files/config/errors/output_level_4.yml
@@ -1,0 +1,2 @@
+printlinter:
+  output_level: 4

--- a/tests/testing_files/config/full_config/config.json
+++ b/tests/testing_files/config/full_config/config.json
@@ -1,12 +1,9 @@
 {
   "printlinter": {
     "target_version": "3.8",
-    "ignored_files": [
-      "tutu.py"
-    ],
-    "disabled_rules": [
-      "PPL003"
-    ],
-    "color": true
+    "ignored_files": ["tutu.py"],
+    "disabled_rules": ["PPL003"],
+    "color": true,
+    "output_level": 1
   }
 }

--- a/tests/testing_files/config/full_config/config.toml
+++ b/tests/testing_files/config/full_config/config.toml
@@ -3,3 +3,4 @@ ignored_files = ["tata.py"]
 disabled_rules = ["PPL004"]
 target_version = "3.7"
 color = false
+output_level = 3

--- a/tests/testing_files/config/full_config/config.yaml
+++ b/tests/testing_files/config/full_config/config.yaml
@@ -3,3 +3,4 @@ printlinter:
   ignored_files: [titi.py]
   disabled_rules: [PPL002]
   color: false
+  output_level: 2

--- a/tests/testing_files/config/full_config/config.yml
+++ b/tests/testing_files/config/full_config/config.yml
@@ -3,3 +3,4 @@ printlinter:
   ignored_files: [toto.py]
   disabled_rules: [PPL001]
   color: true
+  output_level: 1


### PR DESCRIPTION
### Added

- Add a configuration option for a minimize output: `output_level`.
  Possible values:

  - 1 for a really short output with just the number of errors
  - 2 for a short output with number of errors by files
  - 3 for a medium output with number of errors by files and which error and at which lines
  
  Solve issue #40 
