### PR TITLE
Hotfix/toml for python more then 3.10 and accept version 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 21-08-2024
+
+### Fixed
+
+- Fix version accepted to accept 3.11 and 3.12.
+- Fix open toml config file for python version > 3.10.
+
 ## [0.3.1] - 09-08-2024
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The config file allows to specify the python target version for the parser. Use 
 string like this `3.10` or `3.7` to specify the version.
 
 <!-- markdownlint-disable-next-line MD036 -->
-**The python target version MUST be contains between 3.7 and 3.10**
+**The python target version MUST be contains between 3.7 and 3.12**
 
 You can see examples of this config [here](#examples-of-configuration-files).
 

--- a/cli_app/cli.py
+++ b/cli_app/cli.py
@@ -200,7 +200,6 @@ def lint(
     console.print(f"Found [bold red]{len(not_ignored_issues)}[/bold red] errors")
 
     if len(not_ignored_issues) != 0:
-        print("je passe ici")
         raise typer.Exit(1)
 
 

--- a/doc/readme/README.fr.md
+++ b/doc/readme/README.fr.md
@@ -365,7 +365,7 @@ Le fichier de configuration permet de spécifer la version de python utilisé pa
 Utilisez un string qui formater comme `3.10` ou `3.7` pour spécifier la version,
 
 <!-- markdownlint-disable-next-line MD036 -->
-**La version ciblé de python DOIT être entre 3.7 et 3.10**
+**La version ciblé de python DOIT être entre 3.7 et 3.12**
 
 Vous pouvez voir des exemples de configuration [ici](#exemples-de-fichier-configuration).
 

--- a/printlinter/__init__.py
+++ b/printlinter/__init__.py
@@ -20,5 +20,5 @@ from .parser import (  # noqa: F401
 )
 from .visitor import PrintNodeVisitor, contains_print  # noqa: F401
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __app_name__ = "printlinter"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "printlinter"
-version = "0.3.1"
+version = "0.3.2"
 description = "print linter to know where is the test print"
 authors = ["ulysse <ulysse.chosson@obspm.fr>"]
 license = "EUPL v1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ per-file-ignores = {}
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.11.
+# Assume Python 3.10.
 target-version = "py310"
 
 [tool.ruff.mccabe]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -499,17 +499,20 @@ def test_config_from_file_error_on_given_file(given_file, error):
         param(
             "errors/target_version_36.yml",
             ValueError,
-            id="target version is not between 3.7 and 3.11. target_version = 3.6",
+            id="target version is not between 3.7 and max target version. "
+            "Target_version = 3.6",
         ),
         param(
             "errors/target_version_27.yml",
             ValueError,
-            id="target version is not between 3.7 and 3.11. target_version = 2.7",
+            id="target version is not between 3.7 and max target version. "
+            "Target_version = 2.7",
         ),
         param(
-            "errors/target_version_312.yml",
+            "errors/target_version_313.yml",
             ValueError,
-            id="target version is not between 3.7 and 3.11. target_version = 3.12",
+            id="target version is not between 3.7 and max target version. "
+            "Target_version = 3.13",
         ),
     ],
 )

--- a/tests/testing_files/config/errors/target_version_312.yml
+++ b/tests/testing_files/config/errors/target_version_312.yml
@@ -1,2 +1,0 @@
-printlinter:
-  target_version: "3.12"

--- a/tests/testing_files/config/errors/target_version_313.yml
+++ b/tests/testing_files/config/errors/target_version_313.yml
@@ -1,0 +1,2 @@
+printlinter:
+  target_version: "3.13"


### PR DESCRIPTION
## [0.3.2] - 21-08-2024

### Fixed

- Fix version accepted to accept 3.11 and 3.12.
- Fix open toml config file for python version > 3.10.