### PR TITLE
Feature/config sortable output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a configuration option to sort the output: `sorted_by`.
+  Possible values:
+
+  - files to sort by files name.
+  - errors to sort by errors code.
+
 - Add a configuration option for a minimize output: `output_level`.
   Possible values:
 

--- a/printlinter/__init__.py
+++ b/printlinter/__init__.py
@@ -8,6 +8,7 @@ from .classes import (  # noqa: F401
     IssueEnum,
     IssueInfo,
     OutputLevel,
+    SortedOutput,
 )
 from .config import DEFAULT_IGNORED_REP, Config  # noqa: F401
 from .ignored_processing import get_not_ignored_issue  # noqa: F401

--- a/printlinter/classes.py
+++ b/printlinter/classes.py
@@ -6,6 +6,24 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 
+
+class OutputLevel(Enum):
+    """Minimize level enum."""
+
+    DEFAULT = auto()
+    L1 = auto()
+    L2 = auto()
+    L3 = auto()
+
+
+class SortedOutput(Enum):
+    """Sorted output enum."""
+
+    DEFAULT = auto()
+    BY_FILES = auto()
+    BY_ERRORS = auto()
+
+
 Issue = namedtuple("Issue", ["err_code", "name"])
 
 
@@ -22,15 +40,6 @@ class IssueEnum(Issue, Enum):
     SYSSTDERRWRITELINESDETECT = Issue(
         err_code="PPL006", name="sys.stderr.writelines-detected"
     )
-
-
-class OutputLevel(Enum):
-    """Minimize level enum."""
-
-    DEFAULT = auto()
-    L1 = auto()
-    L2 = auto()
-    L3 = auto()
 
 
 @dataclass

--- a/printlinter/config.py
+++ b/printlinter/config.py
@@ -11,7 +11,7 @@ from typing import TypeAlias, cast
 from yaml import safe_load as yaml_load
 
 # Local imports
-from .classes import OutputLevel
+from .classes import OutputLevel, SortedOutput
 
 # In python 3.11, tomllib was added,
 # https://docs.python.org/3/whatsnew/3.11.html#new-modules, so that printlinter is
@@ -107,9 +107,13 @@ class Config:
     "Disabled rules."
 
     color: bool
-    "Colorized output. Default True"
+    "Colorized output. Default: True"
 
     output_level: OutputLevel
+    "Output level. Default: DEFAULT"
+
+    sorted_output: SortedOutput
+    "Sorted output. Default: DEFAULT (Not sorted)"
 
     def __init__(self, path: Path | None = None) -> None:
         """
@@ -133,6 +137,7 @@ class Config:
         self.disabled_rules = cast(list[str], config.get("disabled_rules", []))
         self.color = cast(bool, config.get("color", True))
         self.output_level = self._fix_output_level(config)
+        self.sorted_output = self._fix_sorted_output(config)
 
         # TODO: Add this in user config and merge list give by user and default list
         self.ignored_rep = DEFAULT_IGNORED_REP
@@ -284,3 +289,15 @@ class Config:
                     f"{MIN_OUTPUT_LEVEL} and {MAX_OUTPUT_LEVEL} "
                     f"({', '.join(avaible_values)})."
                 )
+
+    def _fix_sorted_output(self, config: CONFIG_TYPE) -> SortedOutput:
+        sorted_level_from_file = str(config.get("sorted_by", "default"))
+        match sorted_level_from_file:
+            case "default":
+                return SortedOutput.DEFAULT
+            case "files":
+                return SortedOutput.BY_FILES
+            case "errors":
+                return SortedOutput.BY_ERRORS
+            case _:
+                raise ValueError("sorted_by must be a 'files' or 'errors'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,4 +171,5 @@ max-complexity = 10
 suppress-none-returning = true
 
 [tool.printlinter]
-output_level = 3
+output_level = 1
+sorted_by = "files"

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -7,15 +7,57 @@ from pathlib import Path
 
 # Third party imports
 from assertpy import assert_that, soft_assertions
+from rich.console import Console
 
 # First party imports
-from cli_app.cli import _get_errors_msg_by_file, _is_a_file, _is_ignored_rep
-from printlinter import IssueEnum, IssueInfo
+from cli_app.cli import (
+    _display_issues,
+    _get_errors_msg_by_file,
+    _get_issues_depending_sorted_config,
+    _is_a_file,
+    _is_ignored_rep,
+)
+from printlinter import IssueEnum, IssueInfo, OutputLevel, SortedOutput
 
 # Local imports
-from ..conftest import INPUT_FILE_PATH
+from ..conftest import INPUT_FILE_PATH, remove_backslash_n
 
 TESTING_FILES_PATH = INPUT_FILE_PATH / "print"
+
+ISSUES = [
+    IssueInfo(
+        IssueEnum.PRINTDETECT,
+        num_line=5,
+        num_col=0,
+        line_as_str="print('toto')",
+        from_file=Path("toto.py"),
+        ignored=False,
+    ),
+    IssueInfo(
+        IssueEnum.PRINTDETECT,
+        num_line=5,
+        num_col=0,
+        line_as_str="print('titi')",
+        from_file=Path("titi.py"),
+        ignored=False,
+    ),
+    IssueInfo(
+        IssueEnum.PRETTYPRINTDETECT,
+        num_line=9,
+        num_col=0,
+        line_as_str="pprint('toto3')",
+        from_file=Path("toto.py"),
+        ignored=False,
+    ),
+    IssueInfo(
+        IssueEnum.PRINTDETECT,
+        num_line=7,
+        num_col=0,
+        line_as_str="print('toto2')",
+        from_file=Path("toto.py"),
+        ignored=False,
+    ),
+]
 
 
 @pytest.mark.parametrize(
@@ -120,43 +162,142 @@ def test_is_ignored_rep(path, expected):
     ],
 )
 def test_get_errors_msg_by_file(with_number_and_lines, expected):
-    issues = [
-        IssueInfo(
-            IssueEnum.PRINTDETECT,
-            num_line=5,
-            num_col=0,
-            line_as_str="print('toto')",
-            from_file=Path("toto.py"),
-            ignored=False,
-        ),
-        IssueInfo(
-            IssueEnum.PRINTDETECT,
-            num_line=7,
-            num_col=0,
-            line_as_str="print('toto2')",
-            from_file=Path("toto.py"),
-            ignored=False,
-        ),
-        IssueInfo(
-            IssueEnum.PRETTYPRINTDETECT,
-            num_line=9,
-            num_col=0,
-            line_as_str="pprint('toto3')",
-            from_file=Path("toto.py"),
-            ignored=False,
-        ),
-        IssueInfo(
-            IssueEnum.PRINTDETECT,
-            num_line=5,
-            num_col=0,
-            line_as_str="print('titi')",
-            from_file=Path("titi.py"),
-            ignored=False,
-        ),
-    ]
-
     with soft_assertions():
         for exp in expected:
             assert_that(
-                _get_errors_msg_by_file(issues, with_number_and_lines)
+                _get_errors_msg_by_file(ISSUES, with_number_and_lines)
             ).contains(exp)
+
+
+@pytest.mark.parametrize(
+    "output_level, expected",
+    [
+        param(
+            OutputLevel.DEFAULT,
+            [
+                "toto.py",
+                "titi.py",
+                "PPL001",
+                "PPL002",
+                "print('toto')",
+                "print('toto2')",
+                "pprint('toto3')",
+                "print('titi')",
+            ],
+            id="output level = DEFAULT",
+        ),
+        param(OutputLevel.L1, "", id="output level = 1"),
+        param(
+            OutputLevel.L2,
+            ["titi.py - 1 errors detected", "toto.py - 3 errors detected"],
+            id="output level = 2",
+        ),
+        param(
+            OutputLevel.L3,
+            [
+                "titi.py - 1 errors detected",
+                "toto.py - 3 errors detected",
+                "at lines",
+            ],
+            id="output level = 3",
+        ),
+    ],
+)
+def test_display_issues(output_level, expected, capsys):
+    console = Console()
+
+    _display_issues(ISSUES, output_level, console)
+
+    captured_out = capsys.readouterr().out
+    with soft_assertions():
+        if output_level == OutputLevel.L1:
+            assert_that(captured_out).is_equal_to(expected)
+        else:
+            for exp in expected:
+                assert_that(remove_backslash_n(captured_out)).contains(exp)
+
+
+@pytest.mark.parametrize(
+    "sorted_output, expected",
+    [
+        param(SortedOutput.DEFAULT, ISSUES, id="Default sorted output"),
+        param(
+            SortedOutput.BY_FILES,
+            [
+                IssueInfo(
+                    IssueEnum.PRINTDETECT,
+                    num_line=5,
+                    num_col=0,
+                    line_as_str="print('titi')",
+                    from_file=Path("titi.py"),
+                    ignored=False,
+                ),
+                IssueInfo(
+                    IssueEnum.PRINTDETECT,
+                    num_line=5,
+                    num_col=0,
+                    line_as_str="print('toto')",
+                    from_file=Path("toto.py"),
+                    ignored=False,
+                ),
+                IssueInfo(
+                    IssueEnum.PRETTYPRINTDETECT,
+                    num_line=9,
+                    num_col=0,
+                    line_as_str="pprint('toto3')",
+                    from_file=Path("toto.py"),
+                    ignored=False,
+                ),
+                IssueInfo(
+                    IssueEnum.PRINTDETECT,
+                    num_line=7,
+                    num_col=0,
+                    line_as_str="print('toto2')",
+                    from_file=Path("toto.py"),
+                    ignored=False,
+                ),
+            ],
+            id="files sorted output",
+        ),
+        param(
+            SortedOutput.BY_ERRORS,
+            [
+                IssueInfo(
+                    IssueEnum.PRINTDETECT,
+                    num_line=5,
+                    num_col=0,
+                    line_as_str="print('toto')",
+                    from_file=Path("toto.py"),
+                    ignored=False,
+                ),
+                IssueInfo(
+                    IssueEnum.PRINTDETECT,
+                    num_line=5,
+                    num_col=0,
+                    line_as_str="print('titi')",
+                    from_file=Path("titi.py"),
+                    ignored=False,
+                ),
+                IssueInfo(
+                    IssueEnum.PRINTDETECT,
+                    num_line=7,
+                    num_col=0,
+                    line_as_str="print('toto2')",
+                    from_file=Path("toto.py"),
+                    ignored=False,
+                ),
+                IssueInfo(
+                    IssueEnum.PRETTYPRINTDETECT,
+                    num_line=9,
+                    num_col=0,
+                    line_as_str="pprint('toto3')",
+                    from_file=Path("toto.py"),
+                    ignored=False,
+                ),
+            ],
+            id="errors sorted output",
+        ),
+    ],
+)
+def test_get_issues_depending_sorted_config(sorted_output, expected):
+    assert _get_issues_depending_sorted_config(ISSUES, sorted_output) == expected

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from assertpy import assert_that, soft_assertions
 
 # First party imports
-from printlinter import DEFAULT_IGNORED_REP, Config, OutputLevel
+from printlinter import DEFAULT_IGNORED_REP, Config, OutputLevel, SortedOutput
 
 # Local imports
 from ..conftest import INPUT_FILE_PATH
@@ -22,7 +22,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
 # TODO: Create a config generator and generate X (100?) tests with it.
 @pytest.mark.parametrize(
     "given_file, expect_target_version, expect_ignored_files, expect_disabled_rules, "
-    "expect_color, expect_output_level",
+    "expect_color, expect_output_level, expect_sorted_by",
     [
         # full config
         param(
@@ -32,6 +32,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL001"],
             True,
             OutputLevel.L1,
+            SortedOutput.BY_FILES,
             id="yml file",
         ),
         param(
@@ -41,6 +42,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL002"],
             False,
             OutputLevel.L2,
+            SortedOutput.BY_ERRORS,
             id="yaml file",
         ),
         param(
@@ -50,6 +52,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL003"],
             True,
             OutputLevel.L1,
+            SortedOutput.BY_ERRORS,
             id="json file",
         ),
         param(
@@ -59,6 +62,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL004"],
             False,
             OutputLevel.L3,
+            SortedOutput.BY_FILES,
             id="toml file",
         ),
         # partial config
@@ -69,6 +73,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, only target_version",
         ),
         param(
@@ -78,6 +83,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, only ignored_files",
         ),
         param(
@@ -87,6 +93,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL001"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, only disabled_rules",
         ),
         param(
@@ -96,6 +103,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, only color",
         ),
         param(
@@ -105,6 +113,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, target_version and ignored_files",
         ),
         param(
@@ -114,6 +123,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL001"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, target_version and disabled rules",
         ),
         param(
@@ -123,6 +133,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL001"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, ignored_files and disabled_rules",
         ),
         param(
@@ -132,6 +143,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, target_version and color",
         ),
         param(
@@ -141,6 +153,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yml file, target_version, ignored_files and color",
         ),
         param(
@@ -150,6 +163,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, only target_version",
         ),
         param(
@@ -159,6 +173,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, only ignored_files",
         ),
         param(
@@ -168,6 +183,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL002"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, only disabled_rules",
         ),
         param(
@@ -177,6 +193,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, only color",
         ),
         param(
@@ -186,6 +203,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, target_version and ignored_files",
         ),
         param(
@@ -195,6 +213,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL002"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, target_version and disabled rules",
         ),
         param(
@@ -204,6 +223,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL002"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, ignored_files and disabled_rules",
         ),
         param(
@@ -213,6 +233,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, target_version and color",
         ),
         param(
@@ -222,6 +243,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial yaml file, target_version, ignored_files and color",
         ),
         param(
@@ -231,6 +253,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, only target_version",
         ),
         param(
@@ -240,6 +263,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, only ignored_files",
         ),
         param(
@@ -249,6 +273,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL003"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, only disabled_rules",
         ),
         param(
@@ -258,6 +283,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, only color",
         ),
         param(
@@ -267,6 +293,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, target_version and ignored_files",
         ),
         param(
@@ -276,6 +303,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL003"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, target_version and disabled rules",
         ),
         param(
@@ -285,6 +313,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL003"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, ignored_files and disabled_rules",
         ),
         param(
@@ -294,6 +323,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, target_version and color",
         ),
         param(
@@ -303,6 +333,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial json file, target_version, ignored_files and color",
         ),
         param(
@@ -312,6 +343,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only target_version",
         ),
         param(
@@ -321,6 +353,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only ignored_files",
         ),
         param(
@@ -330,6 +363,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL004"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only disabled_rules",
         ),
         param(
@@ -339,6 +373,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only color",
         ),
         param(
@@ -348,6 +383,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only target_version and ignored_files",
         ),
         param(
@@ -357,6 +393,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL004"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only target_version and disabled rules",
         ),
         param(
@@ -366,6 +403,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             ["PPL004"],
             True,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, only ignored_files and disabled_rules",
         ),
         param(
@@ -375,6 +413,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, target_version and color",
         ),
         param(
@@ -384,6 +423,7 @@ TESTING_FILES_PATH = INPUT_FILE_PATH / "config/"
             [],
             False,
             OutputLevel.DEFAULT,
+            SortedOutput.DEFAULT,
             id="partial toml file, target_version, ignored_files and color",
         ),
     ],
@@ -395,6 +435,7 @@ def test_config_from_given_file(
     expect_disabled_rules,
     expect_color,
     expect_output_level,
+    expect_sorted_by,
 ):
     conf = Config(TESTING_FILES_PATH / given_file)
     with soft_assertions():
@@ -403,6 +444,7 @@ def test_config_from_given_file(
         assert_that(conf.disabled_rules).is_equal_to(expect_disabled_rules)
         assert_that(conf.color).is_equal_to(expect_color)
         assert_that(conf.output_level).is_equal_to(expect_output_level)
+        assert_that(conf.sorted_output).is_equal_to(expect_sorted_by)
         assert_that(conf.ignored_rep).is_equal_to(DEFAULT_IGNORED_REP)
 
 
@@ -565,3 +607,8 @@ def test_config_from_file_error_on_target_version(given_file, error):
 def test_config_from_file_error_on_output_level():
     with pytest.raises(ValueError):
         Config(TESTING_FILES_PATH / "errors/output_level_4.yml")
+
+
+def test_config_from_file_error_on_sorted_by():
+    with pytest.raises(ValueError):
+        Config(TESTING_FILES_PATH / "errors/sorted_by_toto.yml")

--- a/tests/testing_files/config/errors/sorted_by_toto.yml
+++ b/tests/testing_files/config/errors/sorted_by_toto.yml
@@ -1,0 +1,2 @@
+printlinter:
+  sorted_by: "toto"

--- a/tests/testing_files/config/full_config/config.json
+++ b/tests/testing_files/config/full_config/config.json
@@ -4,6 +4,7 @@
     "ignored_files": ["tutu.py"],
     "disabled_rules": ["PPL003"],
     "color": true,
-    "output_level": 1
+    "output_level": 1,
+    "sorted_by": "errors"
   }
 }

--- a/tests/testing_files/config/full_config/config.toml
+++ b/tests/testing_files/config/full_config/config.toml
@@ -4,3 +4,4 @@ disabled_rules = ["PPL004"]
 target_version = "3.7"
 color = false
 output_level = 3
+sorted_by = "files"

--- a/tests/testing_files/config/full_config/config.yaml
+++ b/tests/testing_files/config/full_config/config.yaml
@@ -4,3 +4,4 @@ printlinter:
   disabled_rules: [PPL002]
   color: false
   output_level: 2
+  sorted_by: "errors"

--- a/tests/testing_files/config/full_config/config.yml
+++ b/tests/testing_files/config/full_config/config.yml
@@ -4,3 +4,4 @@ printlinter:
   disabled_rules: [PPL001]
   color: true
   output_level: 1
+  sorted_by: "files"


### PR DESCRIPTION
### Added

- Add a configuration option to sort the output: `sorted_by`.
  Possible values:

  - files to sort by files name.
  - errors to sort by errors code.